### PR TITLE
Fix absolute config path for installed plugins

### DIFF
--- a/administrator/components/com_jce/models/editor.php
+++ b/administrator/components/com_jce/models/editor.php
@@ -692,7 +692,11 @@ class WFModelEditor extends WFModelBase
 
             foreach ($installed as $plugin => $path) {
                 $path = dirname($path);
-                $path = str_replace(JURI::root(true), JPATH_SITE, $path);
+                if(empty(JURI::root(true))) {
+                    $path =  JPATH_SITE . $path;
+                } else {
+                    $path =  str_replace(JURI::root(true), JPATH_SITE, $path);
+                }
                 
                 $file = $path . '/classes/config.php';
 


### PR DESCRIPTION
`JURI::root(true)` can return an empty string which results in `$path` not being absolute and the config file not being imported. 

Fixed by checking `JURI::root(true)` for an empty string. If that's the case it suffices to simply prepend JPATH_SITE to the path.