### PR TITLE
Add PDO PostgreSQL driver (pgsql)

### DIFF
--- a/administrator/components/com_jce/helpers/profiles.php
+++ b/administrator/components/com_jce/helpers/profiles.php
@@ -39,6 +39,7 @@ abstract class JceProfilesHelper
                 $driver = 'sqlsrv';
                 break;
             case 'postgresql':
+            case 'pgsql':
                 $driver = 'postgresql';
                 break;
         }
@@ -53,20 +54,6 @@ abstract class JceProfilesHelper
                 // replace prefix
                 $query = $db->replacePrefix((string) $query);
 
-                // Postgresql needs special attention because of the query syntax
-                if ($driver == 'postgresql') {
-                    $query = "CREATE OR REPLACE FUNCTION create_table_if_not_exists (create_sql text)
-                    RETURNS bool as $$
-                    BEGIN
-                        BEGIN
-                            EXECUTE create_sql;
-                            EXCEPTION WHEN duplicate_table THEN RETURN false;
-                        END;
-                        RETURN true;
-                    END; $$
-                    LANGUAGE plpgsql;
-                    SELECT create_table_if_not_exists ('" . $query . "');";
-                }
                 // set query
                 $db->setQuery(trim($query));
 

--- a/administrator/components/com_jce/jce.xml
+++ b/administrator/components/com_jce/jce.xml
@@ -38,6 +38,7 @@
             <file charset="utf8" driver="sqlzure">sql/sqlsrv.sql</file>
             <file charset="utf8" driver="sqlazure">sql/sqlsrv.sql</file>
             <file charset="utf8" driver="postgresql">sql/postgresql.sql</file>
+            <file charset="utf8" driver="pgsql">sql/postgresql.sql</file>
         </sql>
     </install>
 

--- a/administrator/components/com_jce/sql/postgresql.sql
+++ b/administrator/components/com_jce/sql/postgresql.sql
@@ -1,4 +1,4 @@
-CREATE TABLE "#__wf_profiles" (
+CREATE TABLE IF NOT EXISTS "#__wf_profiles" (
     "id" serial NOT NULL,
     "name" character varying(255) NOT NULL,
     "description" text NOT NULL,


### PR DESCRIPTION
The PDO PostgreSQL (pgsql) driver can only execute one query at a time.