### PR TITLE
Do not strip 'font-style: italic' and 'font-weight: bold' from paste

### DIFF
--- a/components/com_jce/editor/tiny_mce/plugins/clipboard/editor_plugin.js
+++ b/components/com_jce/editor/tiny_mce/plugins/clipboard/editor_plugin.js
@@ -1475,8 +1475,10 @@
                     case "font-style":
                         if (value == "normal") {
                             value = "";
+                            return;
                         }
-                        return;
+
+                        break;
 
                     case "mso-element":
                         // Remove track changes code


### PR DESCRIPTION
If you copy content from a Google Doc which contains italic and bold and paste it into a JCE instance, the italic and bold will be stripped out. This happens even if you have configured JCE to preserve all styles. The `font-family` and `font-size` are correctly preserved.

You can test this by copying the sentence from the following document into JCE:

https://docs.google.com/document/d/1cyWjzFPIDZVYD7uZjObx_CcwRDmXtxtSCL3mShwUsF8/edit?usp=sharing

The bug stems from the code that strips out `font-style: normal` and `font-weight: normal`. That code currently calls `return` even if you have `font-style: italic` or `font-weight: 800`. As a result this line after the `switch` statement is skipped,

```
                    outputStyles[name] = value;
```

And, accordingly, the `font-style` and `font-weight` tags are not included in the `outputStyles`, which means that the code which later rewrites the HTML to use `<i>` and `<b>` is never invoked.

The proposed fix only calls `return` when `value == "normal"`. In other cases it merely calls `break`.

I have not completely tested this patch. I did test that removing the `case "font-style":` entirely fixes the problem, so I believe this patch should work as well.